### PR TITLE
fix: add country_code property to User type, liv-7413

### DIFF
--- a/dist/types/user.d.ts
+++ b/dist/types/user.d.ts
@@ -10,6 +10,7 @@ export interface User {
     };
     color?: string;
     company_name?: string;
+    country_code?: string;
     first_name?: string;
     id?: string;
     is_connected?: boolean;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -6,6 +6,7 @@ export interface User {
   },
   color?: string,
   company_name?: string,
+  country_code?: string,
   first_name?: string,
   id?: string,
   is_connected?: boolean,


### PR DESCRIPTION
Logging the `User` object in the JS console, I found out the `country_code` property to be set, along with a bunch of other props. Not sure if that makes sense to add all of them to the User type though.

![image](https://user-images.githubusercontent.com/4329537/162238983-7ea7067a-aa46-4dab-9958-f5968e34c0a9.png)
