### PR TITLE
feat(configuration): add 'pointerEvents' option to stage custom content option, liv-7877

### DIFF
--- a/dist/types/stage.d.ts
+++ b/dist/types/stage.d.ts
@@ -13,6 +13,7 @@ export declare type StageCustomContentOptions = ListenableIframeParams & {
     };
     widget?: boolean;
     onClose?: () => void;
+    pointerEvents?: string;
 };
 export declare type StageCustomContentWrapper = ListenableIframe & RemovableWrapper & {
     hide: () => void;

--- a/src/types/stage.ts
+++ b/src/types/stage.ts
@@ -14,6 +14,7 @@ export type StageCustomContentOptions = ListenableIframeParams & {
     },
     widget?: boolean;
     onClose?: () => void;
+    pointerEvents?: string;
 }
 
 export type StageCustomContentWrapper = ListenableIframe & RemovableWrapper & {


### PR DESCRIPTION
We need to be able to skip the click on the custom content for some notification. For example, the live reaction does not need to intercept the click.
By doing this, we can fix the LIV-7877 (live reaction prevents from clicking on the active speaker when it is on the bottom right)