### PR TITLE
feat(interprefy): add removeOnClose option, liv-8822

### DIFF
--- a/dist/types/stage.d.ts
+++ b/dist/types/stage.d.ts
@@ -13,6 +13,7 @@ export declare type StageCustomContentOptions = ListenableIframeParams & {
     };
     widget?: boolean;
     onClose?: () => void;
+    removeOnClose?: boolean;
     pointerEvents?: string;
 };
 export declare type StageCustomContentWrapper = ListenableIframe & RemovableWrapper & {

--- a/src/types/stage.ts
+++ b/src/types/stage.ts
@@ -14,6 +14,7 @@ export type StageCustomContentOptions = ListenableIframeParams & {
     },
     widget?: boolean;
     onClose?: () => void;
+    removeOnClose?: boolean;
     pointerEvents?: string;
 }
 


### PR DESCRIPTION
This option lets the plugin control the actual removal of the custom content. When set to 'false', the custom content won't be removed.

One use case that is addressed is when a plugin developer wants to implement a confirmation modal before closing a widget, which is needed for the Interprefy integration.